### PR TITLE
#JENKINS-39717: Insufficient error message in PomPropertiesFinder#fin…

### DIFF
--- a/src/main/java/jenkins/plugins/maveninfo/extractor/properties/PomPropertiesFinder.java
+++ b/src/main/java/jenkins/plugins/maveninfo/extractor/properties/PomPropertiesFinder.java
@@ -51,7 +51,9 @@ public class PomPropertiesFinder implements PropertiesFinder {
 					try {
 						digester.parse(is);
 					} catch (SAXException ex) {
-						throw new IOException("Can't read POM: " + p.toString());
+						throw new IOException("Can't read POM: " + p.toString(), ex);
+					} catch (IOException ex) {
+						throw new IOException("Can't read POM: " + p.toString(), ex);
 					} finally {
 						is.close();
 					}


### PR DESCRIPTION
Tries to fix the problem described in issue https://issues.jenkins-ci.org/browse/JENKINS-39717.
