### PR TITLE
Fix intermittent NPE in PomPropertiesFinder#findProperties

### DIFF
--- a/src/main/java/jenkins/plugins/maveninfo/extractor/properties/PomPropertiesFinder.java
+++ b/src/main/java/jenkins/plugins/maveninfo/extractor/properties/PomPropertiesFinder.java
@@ -67,15 +67,13 @@ public class PomPropertiesFinder implements PropertiesFinder {
 
 		FilePath p = workspace.child("pom.xml");
 
-		try {
+		try (InputStream is = p.read()) {
 			Digester digester = createDigester(!Boolean.getBoolean(this.getClass().getName() + ".UNSAFE"));
 			digester.setRules(new ExtendedBaseRules());
 
 			ctx.getRuleSet().addRuleInstances(digester);
 
-			try (InputStream is = p.read()) {
-				digester.parse(is);
-			}
+			digester.parse(is);
 		} catch (SAXException ex) {
 			throw new IOException("Can't read POM: " + p);
 		}

--- a/src/main/java/jenkins/plugins/maveninfo/extractor/properties/PomPropertiesFinder.java
+++ b/src/main/java/jenkins/plugins/maveninfo/extractor/properties/PomPropertiesFinder.java
@@ -51,31 +51,36 @@ public class PomPropertiesFinder implements PropertiesFinder {
 				.getCompiledMainModulePattern();
 
 		MavenModule main = BuildUtils.getMainModule(mmsb, mainPattern);
-		if (main != null) {
-			
-			MavenBuild build = mmsb.getModuleLastBuilds().get(main);
-			if (build != null) {
-				
-				FilePath p = build.getWorkspace().child("pom.xml");
-				if (p != null) {
+		if (main == null) {
+			return;
+		}
 
-					InputStream is = null;
-					try {
-						Digester digester = createDigester(!Boolean.getBoolean(this.getClass().getName() + ".UNSAFE"));
-						digester.setRules(new ExtendedBaseRules());
+		MavenBuild build = mmsb.getModuleLastBuilds().get(main);
+		if (build == null) {
+			return;
+		}
 
-						ctx.getRuleSet().addRuleInstances(digester);
+		FilePath workspace = build.getWorkspace();
+		if (workspace == null) {
+			return;
+		}
 
-						is = p.read();
-						digester.parse(is);
-					} catch (SAXException ex) {
-						throw new IOException("Can't read POM: " + p.toString());
-					} finally {
-						if (is != null) {
-							is.close();
-						}
-					}
-				}
+		FilePath p = workspace.child("pom.xml");
+
+		InputStream is = null;
+		try {
+			Digester digester = createDigester(!Boolean.getBoolean(this.getClass().getName() + ".UNSAFE"));
+			digester.setRules(new ExtendedBaseRules());
+
+			ctx.getRuleSet().addRuleInstances(digester);
+
+			is = p.read();
+			digester.parse(is);
+		} catch (SAXException ex) {
+			throw new IOException("Can't read POM: " + p);
+		} finally {
+			if (is != null) {
+				is.close();
 			}
 		}
 	}

--- a/src/main/java/jenkins/plugins/maveninfo/extractor/properties/PomPropertiesFinder.java
+++ b/src/main/java/jenkins/plugins/maveninfo/extractor/properties/PomPropertiesFinder.java
@@ -67,21 +67,17 @@ public class PomPropertiesFinder implements PropertiesFinder {
 
 		FilePath p = workspace.child("pom.xml");
 
-		InputStream is = null;
 		try {
 			Digester digester = createDigester(!Boolean.getBoolean(this.getClass().getName() + ".UNSAFE"));
 			digester.setRules(new ExtendedBaseRules());
 
 			ctx.getRuleSet().addRuleInstances(digester);
 
-			is = p.read();
-			digester.parse(is);
+			try (InputStream is = p.read()) {
+				digester.parse(is);
+			}
 		} catch (SAXException ex) {
 			throw new IOException("Can't read POM: " + p);
-		} finally {
-			if (is != null) {
-				is.close();
-			}
 		}
 	}
 }


### PR DESCRIPTION
* Add null check on return value of AbstractBuild#getWorkspace
* Minor cleanup of findProperties - flatten method and remove redundant toString call

<!-- Please describe your pull request here. -->

This PR fixes the same bug as #3, but #3 needed to be rebased. This should fix [JENKINS-69080](https://issues.jenkins.io/browse/JENKINS-69080). No test is provided as I don't know how to reproduce the NPE, but adding a single null check here is low risk.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
